### PR TITLE
Update repository references from mkdocs to mkdocs-ng

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ ways, a few examples are:
 - Bug reports and patch reviews
 
 For information about available communication channels please refer to the
-[README](https://github.com/mkdocs/mkdocs#readme) file in our
+[README](https://github.com/mkdocs-ng/mkdocs#readme) file in our
 GitHub repository.
 
 ## Reporting an Issue
@@ -41,7 +41,7 @@ have encountered is fixed in the git master. It is **strongly** recommended
 that you do this within a [virtualenv].
 
 ```bash
-pip install git+https://github.com/mkdocs/mkdocs.git
+pip install git+https://github.com/mkdocs-ng/mkdocs.git
 ```
 
 ## Installing for Development
@@ -159,8 +159,8 @@ updated by running the `extract_messages` command. To update the
 `pot` file for both built-in themes, run these commands:
 
 ```bash
-pybabel extract --project=MkDocs --copyright-holder=MkDocs --msgid-bugs-address='https://github.com/mkdocs/mkdocs/issues' --no-wrap --version="$(hatch version)" --mapping-file mkdocs/themes/babel.cfg --output-file mkdocs/themes/mkdocs/messages.pot mkdocs/themes/mkdocs
-pybabel extract --project=MkDocs --copyright-holder=MkDocs --msgid-bugs-address='https://github.com/mkdocs/mkdocs/issues' --no-wrap --version="$(hatch version)" --mapping-file mkdocs/themes/babel.cfg --output-file mkdocs/themes/readthedocs/messages.pot mkdocs/themes/readthedocs
+pybabel extract --project=MkDocs --copyright-holder=MkDocs --msgid-bugs-address='https://github.com/mkdocs-ng/mkdocs/issues' --no-wrap --version="$(hatch version)" --mapping-file mkdocs/themes/babel.cfg --output-file mkdocs/themes/mkdocs/messages.pot mkdocs/themes/mkdocs
+pybabel extract --project=MkDocs --copyright-holder=MkDocs --msgid-bugs-address='https://github.com/mkdocs-ng/mkdocs/issues' --no-wrap --version="$(hatch version)" --mapping-file mkdocs/themes/babel.cfg --output-file mkdocs/themes/readthedocs/messages.pot mkdocs/themes/readthedocs
 ```
 
 The updated `pot` file should be included in a PR with the updated template.

--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ discussion forums are expected to follow the [PyPA Code of Conduct].
 [codecov-link]: https://codecov.io/github/mkdocs-ng/mkdocs?branch=master
 [pypi-v-image]: https://img.shields.io/pypi/v/mkdocs-ng.svg
 [pypi-v-link]: https://pypi.org/project/mkdocs-ng/
-[GHAction-image]: https://github.com/mkdocs-ng/mkdocs/actions/workflows/ci.yml/badge.svg
-[GHAction-link]: https://github.com/mkdocs-ng/mkdocs/actions/workflows/ci.yml
+[GHAction-image]: https://github.com/mkdocs-ng-ng/mkdocs/actions/workflows/ci.yml/badge.svg
+[GHAction-link]: https://github.com/mkdocs-ng-ng/mkdocs/actions/workflows/ci.yml
 <!-- Links -->
 [mkdocs]: https://www.mkdocs.org
-[Issue]: https://github.com/mkdocs-ng/mkdocs/issues
-[Discussions]: https://github.com/mkdocs-ng/mkdocs/discussions
+[Issue]: https://github.com/mkdocs-ng-ng/mkdocs/issues
+[Discussions]: https://github.com/mkdocs-ng-ng/mkdocs/discussions
 [Chat room]: https://gitter.im/mkdocs-ng/community
 [release-notes]: https://www.mkdocs-ng.org/about/release-notes/
 [Contributing Guide]: https://www.mkdocs-ng.org/about/contributing/
 [PyPA Code of Conduct]: https://www.pypa.io/en/latest/code-of-conduct/
-[catalog]: https://github.com/mkdocs-ng/catalog
+[catalog]: https://github.com/mkdocs-ng-ng/catalog
 
 ## License
 
-[BSD-2-Clause](https://github.com/mkdocs-ng/mkdocs/blob/master/LICENSE)
+[BSD-2-Clause](https://github.com/mkdocs-ng-ng/mkdocs/blob/master/LICENSE)

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -278,7 +278,7 @@ Context: #3429
 
 * The `sitemap.xml.gz` file is slightly more reproducible and no longer changes on every build, but instead only once per day (upon a date change). Context: #3460
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.5.3...1.6.0).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.5.3...1.6.0).
 
 ## Version 1.5.3 (2023-09-18)
 
@@ -292,9 +292,9 @@ Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/comp
 
 *   Plugins can now set `File.page` to their own subclass of `Page`. There is also now a warning if `File.page` is set to anything other than a strict subclass of `Page`. (#3367, #3381)
 
-    Note that just instantiating a `Page` [sets the file automatically](https://github.com/mkdocs/mkdocs/blob/f94ab3f62d0416d484d81a0c695c8ca86ab3b975/mkdocs/structure/pages.py#L34), so care needs to be taken not to create an unneeded `Page`.
+    Note that just instantiating a `Page` [sets the file automatically](https://github.com/mkdocs-ng/mkdocs/blob/f94ab3f62d0416d484d81a0c695c8ca86ab3b975/mkdocs/structure/pages.py#L34), so care needs to be taken not to create an unneeded `Page`.
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.5.2...1.5.3).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.5.2...1.5.3).
 
 ## Version 1.5.2 (2023-08-02)
 
@@ -306,7 +306,7 @@ Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/comp
 
     Plugins should be free to append strings to `config.extra_javascript`, but when reading the values, they must still make sure to read it as `str(value)` in case it is an `ExtraScriptValue` item. For querying the attributes such as `.type` you need to check `isinstance` first. Static type checking will guide you in that. (#3324)
 
-See [commit log](https://github.com/mkdocs/mkdocs/compare/1.5.1...1.5.2).
+See [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.5.1...1.5.2).
 
 ## Version 1.5.1 (2023-07-28)
 
@@ -314,7 +314,7 @@ See [commit log](https://github.com/mkdocs/mkdocs/compare/1.5.1...1.5.2).
 
 *   Bugfix (regression in 1.5.0): Prevent errors for special setups that have 3 conflicting files, such as `index.html`, `index.md` *and* `README.md` (#3314)
 
-See [commit log](https://github.com/mkdocs/mkdocs/compare/1.5.0...1.5.1).
+See [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.5.0...1.5.1).
 
 ## Version 1.5.0 (2023-07-26)
 
@@ -338,7 +338,7 @@ Context: #3205
 
 ### MkDocs has an official catalog of plugins
 
-Check out <https://github.com/mkdocs/catalog> and add all your general-purpose plugins, themes and extensions there, so that they can be looked up through `mkdocs get-deps`.
+Check out <https://github.com/mkdocs-ng/catalog> and add all your general-purpose plugins, themes and extensions there, so that they can be looked up through `mkdocs get-deps`.
 
 This was renamed from "best-of-mkdocs" and received significant updates. In addition to `pip` installation commands, the page now shows the config boilerplate needed to add a plugin.
 
@@ -485,7 +485,7 @@ See [**documentation**](../dev-guide/themes.md#picking-up-css-and-javascript-fro
 
 *   `File` has a new attribute `inclusion`. Its value is calculated from both the `exclude_docs` and `not_in_nav` configs, and implements their behavior. Plugins can read this value or write to it. New `File` instances by default follow whatever the configs say, but plugins can choose to make this decision explicitly, per file.
 
-*   When creating a `File`, one can now set a `dest_uri` directly, rather than having to update it (and other dependent attributes) after creation. [Context](https://github.com/mkdocs/mkdocs/commit/d5af6426c52421f1113f6dcc591de1e01bea48bd)
+*   When creating a `File`, one can now set a `dest_uri` directly, rather than having to update it (and other dependent attributes) after creation. [Context](https://github.com/mkdocs-ng/mkdocs/commit/d5af6426c52421f1113f6dcc591de1e01bea48bd)
 
 *   A new config option was added - `DictOfItems`. Similarly to `ListOfItems`, it validates a mapping of config options that all have the same type. Keys are arbitrary but always strings. Context: #3242
 
@@ -499,7 +499,7 @@ See [**documentation**](../dev-guide/themes.md#picking-up-css-and-javascript-fro
 
     Context: #3245
 
-*   `SubConfig` config option can be conveniently subclassed with a particular type of config specified. For example, `class ExtraScript(SubConfig[ExtraScriptValue]):`. To see how this is useful, search for this class in code. [Context](https://github.com/mkdocs/mkdocs/commit/73e503990e3e3504bfe1cb627d41a7e97970687e)
+*   `SubConfig` config option can be conveniently subclassed with a particular type of config specified. For example, `class ExtraScript(SubConfig[ExtraScriptValue]):`. To see how this is useful, search for this class in code. [Context](https://github.com/mkdocs-ng/mkdocs/commit/73e503990e3e3504bfe1cb627d41a7e97970687e)
 
 *   Bugfix: `SubConfig` had a bug where paths (from `FilesystemObject` options) were not made relative to the main config file as intended, because `config_file_path` was not properly inherited to it. This is now fixed. Context: #3265
 
@@ -512,15 +512,15 @@ See [**documentation**](../dev-guide/themes.md#picking-up-css-and-javascript-fro
         async_ = Type(bool, default=False)
     ```
 
-    Previously making a config key with a reserved name was impossible with new-style schemas. [Context](https://github.com/mkdocs/mkdocs/commit/1db8e884fa7135a49adf7740add5d875a16a18bc)
+    Previously making a config key with a reserved name was impossible with new-style schemas. [Context](https://github.com/mkdocs-ng/mkdocs/commit/1db8e884fa7135a49adf7740add5d875a16a18bc)
 
 *   `Theme` has its attributes properly declared and gained new attributes `theme.locale`, `theme.custom_dir`.
 
 *   Some type annotations were made more precise. For example:
 
-    * The `context` parameter has gained the type `TemplateContext` (`TypedDict`). [Context](https://github.com/mkdocs/mkdocs/commit/0f793b9984c7e6a1d53ce874e7d17b6d27ebf4b2)
-    * The classes `Page`, `Section`, `Link` now have a common base class `StructureItem`. [Context](https://github.com/mkdocs/mkdocs/commit/01be507e30b05db0a4c44ef05ba62b2098010653)
-    * Some methods stopped accepting `Config` and only accept `MkDocsConfig` as was originally intended. [Context](https://github.com/mkdocs/mkdocs/commit/c459cd24fc0320333f51525e9cf681d4a8370f50)
+    * The `context` parameter has gained the type `TemplateContext` (`TypedDict`). [Context](https://github.com/mkdocs-ng/mkdocs/commit/0f793b9984c7e6a1d53ce874e7d17b6d27ebf4b2)
+    * The classes `Page`, `Section`, `Link` now have a common base class `StructureItem`. [Context](https://github.com/mkdocs-ng/mkdocs/commit/01be507e30b05db0a4c44ef05ba62b2098010653)
+    * Some methods stopped accepting `Config` and only accept `MkDocsConfig` as was originally intended. [Context](https://github.com/mkdocs-ng/mkdocs/commit/c459cd24fc0320333f51525e9cf681d4a8370f50)
     * `config.mdx_configs` got a proper type. Context: #3229
 
 ### Theme updates
@@ -547,7 +547,7 @@ This can be used for config overrides on the fly. See updated section at the bot
 
 The command to use this is `mkdocs build -f -`. In previous versions doing this led to an error.
 
-[Context](https://github.com/mkdocs/mkdocs/commit/d5bb15fa108da86a8e53fb7d84109d8f8d9d6453)
+[Context](https://github.com/mkdocs-ng/mkdocs/commit/d5bb15fa108da86a8e53fb7d84109d8f8d9d6453)
 
 ### New command line flags
 
@@ -569,13 +569,13 @@ The command to use this is `mkdocs build -f -`. In previous versions doing this 
 
 *   Accessing the `user_configs` attribute of a `Config` is deprecated. Note: instead of `config.user_configs[*]['theme']['custom_dir']`, please use the new attribute `config.theme.custom_dir`.
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.4.3...1.5.0).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.4.3...1.5.0).
 
 ## Version 1.4.3 (2023-05-02)
 
 *   Bugfix: for the `hooks` feature, modules no longer fail to load if using some advanced Python features like dataclasses (#3193)
 
-*   Bugfix: Don't create `None` sitemap entries if the page has no populated URL - affects sites that exclude some files from navigation ([`07a297b`](https://github.com/mkdocs/mkdocs/commit/07a297b3b4de4a1b49469b1497ee34039b9f38fa))
+*   Bugfix: Don't create `None` sitemap entries if the page has no populated URL - affects sites that exclude some files from navigation ([`07a297b`](https://github.com/mkdocs-ng/mkdocs/commit/07a297b3b4de4a1b49469b1497ee34039b9f38fa))
 
 *   "readthedocs" theme:
     * Accessibility: add aria labels to Home logo (#3129) and search inputs (#3046)
@@ -586,7 +586,7 @@ Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/comp
     * Fixed `zh_CN` translation (#3125)
     * `tr_TR` translation becomes just `tr` - usage should remain unaffected (#3195)
 
-See [commit log](https://github.com/mkdocs/mkdocs/compare/1.4.2...1.4.3).
+See [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.4.2...1.4.3).
 
 ## Version 1.4.2 (2022-11-01)
 
@@ -612,7 +612,7 @@ See [commit log](https://github.com/mkdocs/mkdocs/compare/1.4.2...1.4.3).
 
 *   Plugin-related warnings look more readable (#3016)
 
-See [commit log](https://github.com/mkdocs/mkdocs/compare/1.4.1...1.4.2).
+See [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.4.1...1.4.2).
 
 ## Version 1.4.1 (2022-10-15)
 
@@ -635,7 +635,7 @@ See [commit log](https://github.com/mkdocs/mkdocs/compare/1.4.1...1.4.2).
 
 *   The ['mkdocs' package](https://pypi.org/project/mkdocs/#files) (wheel and source) is now produced by Hatch build system and pyproject.toml instead of setup.py (#2988)
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.4.0...1.4.1).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.4.0...1.4.1).
 
 ## Version 1.4.0 (2022-09-27)
 
@@ -687,7 +687,7 @@ To not make a breaking change, there's no change to how *this* property is used,
 
 These consistently use forward slashes, and are now the definitive source that MkDocs itself uses.
 
-See [source code](https://github.com/mkdocs/mkdocs/blob/1.4.0/mkdocs/structure/files.py#L151).
+See [source code](https://github.com/mkdocs-ng/mkdocs/blob/1.4.0/mkdocs/structure/files.py#L151).
 
 As a related tip: you should also stop using `os.path.*` or `pathlib.Path()` to deal with these paths, and instead use `posixpath.*` or `pathlib.PurePosixPath()`
 
@@ -697,11 +697,11 @@ As a related tip: you should also stop using `os.path.*` or `pathlib.Path()` to 
 
 MkDocs' plugin event methods now have type annotations. You might have been adding annotations to events already, but now they will be validated to match the original.
 
-See [source code](https://github.com/mkdocs/mkdocs/blob/1.4.0/mkdocs/plugins.py#L165) and [documentation](../dev-guide/plugins.md#events).
+See [source code](https://github.com/mkdocs-ng/mkdocs/blob/1.4.0/mkdocs/plugins.py#L165) and [documentation](../dev-guide/plugins.md#events).
 
-One big update is that now you should annotate method parameters more specifically as `config: defaults.MkDocsConfig` instead of `config: base.Config`. This not only makes it clear that it is the [main config of MkDocs itself](https://github.com/mkdocs/mkdocs/blob/1.4.0/mkdocs/config/defaults.py), but also provides type-safe access through attributes of the object (see next section).
+One big update is that now you should annotate method parameters more specifically as `config: defaults.MkDocsConfig` instead of `config: base.Config`. This not only makes it clear that it is the [main config of MkDocs itself](https://github.com/mkdocs-ng/mkdocs/blob/1.4.0/mkdocs/config/defaults.py), but also provides type-safe access through attributes of the object (see next section).
 
-See [source code](https://github.com/mkdocs/mkdocs/blob/1.4.0/mkdocs/config/defaults.py) and [documentation](../dev-guide/plugins.md#on_event_name).
+See [source code](https://github.com/mkdocs-ng/mkdocs/blob/1.4.0/mkdocs/config/defaults.py) and [documentation](../dev-guide/plugins.md#on_event_name).
 
 #### Rework ConfigOption schemas as class-based (#2962)
 
@@ -846,7 +846,7 @@ Deprecated config option classes: `ConfigItems` (#2983), `OptionallyRequired` (#
 
 *   Bugfix (regression in 1.2): Support listening on an IPv6 address in `mkdocs serve`. (#2951)
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.3.1...1.4.0).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.3.1...1.4.0).
 
 ## Version 1.3.1 (2022-07-19)
 
@@ -861,7 +861,7 @@ Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/comp
 *   Built-in themes now also support these languages:
     * Italian (#2860)
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.3.0...1.3.1).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.3.0...1.3.1).
 
 ## Version 1.3.0 (2022-03-26)
 
@@ -911,9 +911,9 @@ Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/comp
 
 *   Recursively validate `nav` (#2680)
 
-    Validation of the nested `nav` structure has been reworked to report errors early and reliably. Some [edge cases](https://github.com/mkdocs/mkdocs/blob/b7272150bbc9bf8f66c878f6517742de3528972b/mkdocs/tests/config/config_options_tests.py#L783) have been declared invalid.
+    Validation of the nested `nav` structure has been reworked to report errors early and reliably. Some [edge cases](https://github.com/mkdocs-ng/mkdocs/blob/b7272150bbc9bf8f66c878f6517742de3528972b/mkdocs/tests/config/config_options_tests.py#L783) have been declared invalid.
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.2.3...1.3.0).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.2.3...1.3.0).
 
 ## Version 1.2.4 (2022-03-26)
 
@@ -942,7 +942,7 @@ Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/comp
 
 *   Bugfix: Python version 3.10 was displayed incorrectly in `--version` (#2618)
 
-Other small improvements; see [commit log](https://github.com/mkdocs/mkdocs/compare/1.2.2...1.2.3).
+Other small improvements; see [commit log](https://github.com/mkdocs-ng/mkdocs/compare/1.2.2...1.2.3).
 
 ## Version 1.2.2 (2021-07-18)
 
@@ -2037,7 +2037,7 @@ A new index with all the contents from a MkDocs build is created in the
 This new file is created on every MkDocs build (with `mkdocs build`) and
 no configuration is needed to enable it.
 
-[future release]: https://github.com/mkdocs/mkdocs/pull/481
+[future release]: https://github.com/mkdocs-ng/mkdocs/pull/481
 [site_dir]: ../user-guide/configuration.md#site_dir
 
 #### Change the pages configuration

--- a/docs/dev-guide/plugins.md
+++ b/docs/dev-guide/plugins.md
@@ -561,6 +561,6 @@ You should publish a package on [PyPI], then add it to the [Catalog] for discove
 [post_template]: #on_post_template
 [static_templates]: ../user-guide/configuration.md#static_templates
 [Template Events]: #template-events
-[catalog]: https://github.com/mkdocs/catalog
+[catalog]: https://github.com/mkdocs-ng/catalog
 [on_build_error]: #on_build_error
 [PyPI]: https://pypi.org/

--- a/docs/dev-guide/themes.md
+++ b/docs/dev-guide/themes.md
@@ -15,9 +15,9 @@ basic, yet complete, theme with all the boilerplate required. **You can find
 this base theme on [GitHub][basic theme]**. It contains detailed comments in
 the code to describe the different features and their usage.
 
-[community wiki]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
-[catalog]: https://github.com/mkdocs/catalog#-theming
-[basic theme]: https://github.com/mkdocs/mkdocs-basic-theme
+[community wiki]: https://github.com/mkdocs-ng/mkdocs/wiki/MkDocs-Themes
+[catalog]: https://github.com/mkdocs-ng/catalog#-theming
+[basic theme]: https://github.com/mkdocs-ng/mkdocs-basic-theme
 
 ## Creating a custom theme
 
@@ -635,7 +635,7 @@ following `extra` configuration:
 extra:
   version: 0.13.0
   links:
-    - https://github.com/mkdocs
+    - https://github.com/mkdocs-ng
     - https://docs.readthedocs.org/en/latest/builds.html#mkdocs
     - https://www.mkdocs.org/
 ```
@@ -795,7 +795,7 @@ Themes should expect the index to not be present, but can choose to use the
 index when it is available. The `index` object was new in MkDocs version *1.0*.
 
 [Jinja2 template]: https://jinja.palletsprojects.com/
-[built-in themes]: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/themes
+[built-in themes]: https://github.com/mkdocs-ng/mkdocs/tree/master/mkdocs/themes
 [theme's configuration file]: #theme-configuration
 [lunr.js]: https://lunrjs.com/
 [site_dir]: ../user-guide/configuration.md#site_dir

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -206,8 +206,8 @@ To get help with MkDocs, please use the [GitHub discussions] or [GitHub issues].
 [docs_dir]: user-guide/configuration.md#docs_dir
 [deploy]: user-guide/deploying-your-docs.md
 [nav]: user-guide/configuration.md#nav
-[GitHub discussions]: https://github.com/mkdocs/mkdocs/discussions
-[GitHub issues]: https://github.com/mkdocs/mkdocs/issues
+[GitHub discussions]: https://github.com/mkdocs-ng/mkdocs/discussions
+[GitHub issues]: https://github.com/mkdocs-ng/mkdocs/issues
 [site_name]: user-guide/configuration.md#site_name
 [theme]: user-guide/configuration.md#theme
 [User Guide]: user-guide/README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,8 @@ configuration file. Start by reading the [introductory tutorial], then check the
             <a href="user-guide/choosing-your-theme/#mkdocs">mkdocs</a> and
             <a href="user-guide/choosing-your-theme/#readthedocs">readthedocs</a>,
             select one of the third-party themes
-            (on the <a href="https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes">MkDocs Themes</a> wiki page
-            as well as the <a href="https://github.com/mkdocs/catalog#-theming">MkDocs Catalog</a>),
+            (on the <a href="https://github.com/mkdocs-ng/mkdocs/wiki/MkDocs-Themes">MkDocs Themes</a> wiki page
+            as well as the <a href="https://github.com/mkdocs-ng/catalog#-theming">MkDocs Catalog</a>),
             or <a href="dev-guide/themes/">build your own</a>.
         </p>
       </div>

--- a/docs/user-guide/choosing-your-theme.md
+++ b/docs/user-guide/choosing-your-theme.md
@@ -224,6 +224,6 @@ WARNING: Installing an MkDocs theme means installing a Python package and execut
 [setup-GA4]: https://support.google.com/analytics/answer/9304153?hl=en&ref_topic=9303319
 [upgrade-GA4]: https://support.google.com/analytics/answer/9744165?hl=en&ref_topic=9303319
 [Read the Docs]: https://readthedocs.org/
-[community wiki]: https://github.com/mkdocs/mkdocs/wiki/MkDocs-Themes
-[catalog]: https://github.com/mkdocs/catalog#-theming
+[community wiki]: https://github.com/mkdocs-ng/mkdocs/wiki/MkDocs-Themes
+[catalog]: https://github.com/mkdocs-ng/catalog#-theming
 [localizing your theme]: localizing-your-theme.md

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1270,7 +1270,7 @@ echo '{INHERIT: mkdocs.yml, site_name: "Renamed site"}' | mkdocs build -f -
 [smarty]: https://python-markdown.github.io/extensions/smarty/
 [exts]: https://python-markdown.github.io/extensions/
 [Python-Markdown wiki]: https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions
-[catalog]: https://github.com/mkdocs/catalog
+[catalog]: https://github.com/mkdocs-ng/catalog
 [configuring pages and navigation]: writing-your-docs.md#configure-pages-and-navigation
 [Meta-Data]: writing-your-docs.md#meta-data
 [theme_dir]: customizing-your-theme.md#using-the-theme-custom_dir

--- a/docs/user-guide/customizing-your-theme.md
+++ b/docs/user-guide/customizing-your-theme.md
@@ -219,7 +219,7 @@ any additional CSS files included in the `custom_dir`.
 [custom_dir]: ./configuration.md#custom_dir
 [name]: ./configuration.md#name
 [mkdocs]: ./choosing-your-theme.md#mkdocs
-[browse source]: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/themes/mkdocs
+[browse source]: https://github.com/mkdocs-ng/mkdocs/tree/master/mkdocs/themes/mkdocs
 [Template Variables]: ../dev-guide/themes.md#template-variables
 [Jinja documentation]: https://jinja.palletsprojects.com/en/latest/templates/#template-inheritance
 [super block]: https://jinja.palletsprojects.com/en/latest/templates/#super-blocks

--- a/docs/user-guide/deploying-your-docs.md
+++ b/docs/user-guide/deploying-your-docs.md
@@ -100,7 +100,7 @@ documentation on [Troubleshooting custom domains].
 [remote_branch]: ./configuration.md#remote_branch
 [Custom Domain]: https://help.github.com/articles/adding-or-removing-a-custom-domain-for-your-github-pages-site
 [docs_dir]: ./configuration.md#docs_dir
-[CNAME file]: https://github.com/mkdocs/mkdocs/blob/master/docs/CNAME
+[CNAME file]: https://github.com/mkdocs-ng/mkdocs/blob/master/docs/CNAME
 [Troubleshooting custom domains]: https://help.github.com/articles/troubleshooting-custom-domains/
 
 ## Read the Docs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://www.mkdocs.org/
 site_description: Project documentation with Markdown.
 site_author: MkDocs Team
 
-repo_url: https://github.com/mkdocs/mkdocs/
+repo_url: https://github.com/mkdocs-ng/mkdocs/
 edit_uri: blob/master/docs/
 
 theme:

--- a/mkdocs/commands/build.py
+++ b/mkdocs/commands/build.py
@@ -68,9 +68,9 @@ def _build_template(
     if utils.is_error_template(name):
         # Force absolute URLs in the nav of error pages and account for the
         # possibility that the docs root might be different than the server root.
-        # See https://github.com/mkdocs/mkdocs/issues/77.
+        # See https://github.com/mkdocs-ng/mkdocs/issues/77.
         # However, if site_url is not set, assume the docs root and server root
-        # are the same. See https://github.com/mkdocs/mkdocs/issues/1598.
+        # are the same. See https://github.com/mkdocs-ng/mkdocs/issues/1598.
         base_url = urlsplit(config.site_url or '/').path
     else:
         base_url = utils.get_relative_url('.', name)

--- a/mkdocs/tests/config/config_options_legacy_tests.py
+++ b/mkdocs/tests/config/config_options_legacy_tests.py
@@ -467,7 +467,7 @@ class EditURITest(TestCase):
     def test_repo_name_github(self):
         conf = self.get_config(
             self.Schema,
-            {'repo_url': "https://github.com/mkdocs/mkdocs"},
+            {'repo_url': "https://github.com/mkdocs-ng/mkdocs"},
         )
         self.assertEqual(conf['repo_name'], "GitHub")
 
@@ -495,10 +495,10 @@ class EditURITest(TestCase):
     def test_edit_uri_github(self):
         conf = self.get_config(
             self.Schema,
-            {'repo_url': "https://github.com/mkdocs/mkdocs"},
+            {'repo_url': "https://github.com/mkdocs-ng/mkdocs"},
         )
         self.assertEqual(conf['edit_uri'], 'edit/master/docs/')
-        self.assertEqual(conf['repo_url'], "https://github.com/mkdocs/mkdocs")
+        self.assertEqual(conf['repo_url'], "https://github.com/mkdocs-ng/mkdocs")
 
     def test_edit_uri_bitbucket(self):
         conf = self.get_config(
@@ -526,7 +526,7 @@ class EditURITest(TestCase):
     def test_repo_name_custom_and_empty_edit_uri(self):
         conf = self.get_config(
             self.Schema,
-            {'repo_url': "https://github.com/mkdocs/mkdocs", 'repo_name': 'mkdocs'},
+            {'repo_url': "https://github.com/mkdocs-ng/mkdocs", 'repo_name': 'mkdocs'},
         )
         self.assertEqual(conf['edit_uri'], 'edit/master/docs/')
 
@@ -534,7 +534,7 @@ class EditURITest(TestCase):
         conf = self.get_config(
             self.Schema,
             {
-                'repo_url': "https://github.com/mkdocs/mkdocs",
+                'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                 'edit_uri_template': 'edit/foo/docs/{path}',
             },
         )
@@ -547,7 +547,7 @@ class EditURITest(TestCase):
             self.get_config(
                 self.Schema,
                 {
-                    'repo_url': "https://github.com/mkdocs/mkdocs",
+                    'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                     'edit_uri_template': 'edit/master/{path',
                 },
             )
@@ -556,7 +556,7 @@ class EditURITest(TestCase):
             self.get_config(
                 self.Schema,
                 {
-                    'repo_url': "https://github.com/mkdocs/mkdocs",
+                    'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                     'edit_uri_template': 'edit/master/{path!z}',
                 },
             )
@@ -565,7 +565,7 @@ class EditURITest(TestCase):
             self.get_config(
                 self.Schema,
                 {
-                    'repo_url': "https://github.com/mkdocs/mkdocs",
+                    'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                     'edit_uri_template': 'edit/master/{foo}',
                 },
             )
@@ -574,7 +574,7 @@ class EditURITest(TestCase):
         conf = self.get_config(
             self.Schema,
             {
-                'repo_url': "https://github.com/mkdocs/mkdocs",
+                'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                 'edit_uri': 'edit',
                 'edit_uri_template': 'edit/master/{path}',
             },

--- a/mkdocs/tests/config/config_options_tests.py
+++ b/mkdocs/tests/config/config_options_tests.py
@@ -456,7 +456,7 @@ class EditURITest(TestCase):
     def test_repo_name_github(self) -> None:
         conf = self.get_config(
             self.Schema,
-            {'repo_url': "https://github.com/mkdocs/mkdocs"},
+            {'repo_url': "https://github.com/mkdocs-ng/mkdocs"},
         )
         assert_type(conf.repo_name, Optional[str])
         self.assertEqual(conf.repo_name, "GitHub")
@@ -485,12 +485,12 @@ class EditURITest(TestCase):
     def test_edit_uri_github(self) -> None:
         conf = self.get_config(
             self.Schema,
-            {'repo_url': "https://github.com/mkdocs/mkdocs"},
+            {'repo_url': "https://github.com/mkdocs-ng/mkdocs"},
         )
         assert_type(conf.edit_uri, Optional[str])
         assert_type(conf.repo_url, Optional[str])
         self.assertEqual(conf.edit_uri, 'edit/master/docs/')
-        self.assertEqual(conf.repo_url, "https://github.com/mkdocs/mkdocs")
+        self.assertEqual(conf.repo_url, "https://github.com/mkdocs-ng/mkdocs")
 
     def test_edit_uri_bitbucket(self) -> None:
         conf = self.get_config(
@@ -518,7 +518,7 @@ class EditURITest(TestCase):
     def test_repo_name_custom_and_empty_edit_uri(self) -> None:
         conf = self.get_config(
             self.Schema,
-            {'repo_url': "https://github.com/mkdocs/mkdocs", 'repo_name': 'mkdocs'},
+            {'repo_url': "https://github.com/mkdocs-ng/mkdocs", 'repo_name': 'mkdocs'},
         )
         self.assertEqual(conf.edit_uri, 'edit/master/docs/')
 
@@ -526,7 +526,7 @@ class EditURITest(TestCase):
         conf = self.get_config(
             self.Schema,
             {
-                'repo_url': "https://github.com/mkdocs/mkdocs",
+                'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                 'edit_uri_template': 'edit/foo/docs/{path}',
             },
         )
@@ -540,7 +540,7 @@ class EditURITest(TestCase):
             self.get_config(
                 self.Schema,
                 {
-                    'repo_url': "https://github.com/mkdocs/mkdocs",
+                    'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                     'edit_uri_template': 'edit/master/{path',
                 },
             )
@@ -549,7 +549,7 @@ class EditURITest(TestCase):
             self.get_config(
                 self.Schema,
                 {
-                    'repo_url': "https://github.com/mkdocs/mkdocs",
+                    'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                     'edit_uri_template': 'edit/master/{path!z}',
                 },
             )
@@ -558,7 +558,7 @@ class EditURITest(TestCase):
             self.get_config(
                 self.Schema,
                 {
-                    'repo_url': "https://github.com/mkdocs/mkdocs",
+                    'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                     'edit_uri_template': 'edit/master/{foo}',
                 },
             )
@@ -567,7 +567,7 @@ class EditURITest(TestCase):
         conf = self.get_config(
             self.Schema,
             {
-                'repo_url': "https://github.com/mkdocs/mkdocs",
+                'repo_url': "https://github.com/mkdocs-ng/mkdocs",
                 'edit_uri': 'edit',
                 'edit_uri_template': 'edit/master/{path}',
             },

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -45,7 +45,7 @@ class TestGitHubDeploy(unittest.TestCase):
             b'',
         )
 
-        expected = ('https://', 'mkdocs/mkdocs.git')
+        expected = ('https://', 'mkdocs-ng/mkdocs.git')
         self.assertEqual(expected, gh_deploy._get_remote_url('origin'))
 
     @mock.patch('subprocess.Popen')

--- a/mkdocs/tests/gh_deploy_tests.py
+++ b/mkdocs/tests/gh_deploy_tests.py
@@ -41,7 +41,7 @@ class TestGitHubDeploy(unittest.TestCase):
     @mock.patch('subprocess.Popen')
     def test_get_remote_url_http(self, mock_popeno):
         mock_popeno().communicate.return_value = (
-            b'https://github.com/mkdocs/mkdocs.git\n',
+            b'https://github.com/mkdocs-ng/mkdocs.git\n',
             b'',
         )
 

--- a/mkdocs/tests/integration/complicated_config/mkdocs.yml
+++ b/mkdocs/tests/integration/complicated_config/mkdocs.yml
@@ -24,7 +24,7 @@ copyright: "Dougal Matthews"
 dev_addr: ::1:8000
 use_directory_urls: false
 
-repo_url: https://github.com/mkdocs/mkdocs/tree/master/mkdocs/tests/integration
+repo_url: https://github.com/mkdocs-ng/mkdocs/tree/master/mkdocs/tests/integration
 repo_name: "GitHub"
 
 extra_css: ["tweak.css"]

--- a/mkdocs/tests/integration/projects.yaml
+++ b/mkdocs/tests/integration/projects.yaml
@@ -1,5 +1,5 @@
 # DO NOT UPDATE THIS FILE, only for tests.
-# This is an intentionally small subset of https://github.com/mkdocs/catalog
+# This is an intentionally small subset of https://github.com/mkdocs-ng/catalog
 projects:
 - name: Material for MkDocs
   mkdocs_theme: material

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -555,9 +555,9 @@ class PageTests(unittest.TestCase):
                 edit_url2='http://github.com/mkdocs/mkdocs/edit/master/docs/sub1/non-index.md',
             ),
             dict(
-                config={'repo_url': 'https://github.com/mkdocs/mkdocs/'},
-                edit_url='https://github.com/mkdocs/mkdocs/edit/master/docs/testing.md',
-                edit_url2='https://github.com/mkdocs/mkdocs/edit/master/docs/sub1/non-index.md',
+                config={'repo_url': 'https://github.com/mkdocs-ng/mkdocs/'},
+                edit_url='https://github.com/mkdocs-ng/mkdocs/edit/master/docs/testing.md',
+                edit_url2='https://github.com/mkdocs-ng/mkdocs/edit/master/docs/sub1/non-index.md',
             ),
             dict(
                 config={'repo_url': 'http://example.com'},
@@ -701,16 +701,16 @@ class PageTests(unittest.TestCase):
         for case in [
             dict(
                 edit_uri='hooks.py',
-                expected_edit_url='https://github.com/mkdocs/mkdocs/edit/master/docs/hooks.py',
+                expected_edit_url='https://github.com/mkdocs-ng/mkdocs/edit/master/docs/hooks.py',
             ),
             dict(
                 edit_uri='../scripts/hooks.py',
-                expected_edit_url='https://github.com/mkdocs/mkdocs/edit/master/scripts/hooks.py',
+                expected_edit_url='https://github.com/mkdocs-ng/mkdocs/edit/master/scripts/hooks.py',
             ),
             dict(edit_uri=None, expected_edit_url=None),
         ]:
             with self.subTest(case['edit_uri']):
-                cfg = load_config(repo_url='https://github.com/mkdocs/mkdocs')
+                cfg = load_config(repo_url='https://github.com/mkdocs-ng/mkdocs')
                 fl = File('testing.md', cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
                 fl.edit_uri = case['edit_uri']
                 pg = Page('Foo', fl, cfg)

--- a/mkdocs/tests/theme_tests.py
+++ b/mkdocs/tests/theme_tests.py
@@ -107,7 +107,7 @@ class ThemeTests(unittest.TestCase):
 
     def test_empty_config_file(self):
         # Test for themes with *empty* mkdocs_theme.yml.
-        # See https://github.com/mkdocs/mkdocs/issues/3699
+        # See https://github.com/mkdocs-ng/mkdocs/issues/3699
         m = mock.Mock(
             # yaml.load returns "None" for an empty file
             side_effect=[None]

--- a/mkdocs/themes/mkdocs/locales/de/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/de/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2021-10-24 00:09+0200\n"
 "Last-Translator: Marc Dietz <marc@projectleviathan.de>\n"

--- a/mkdocs/themes/mkdocs/locales/es/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/es/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2021-05-07 12:06+0200\n"
 "Last-Translator: Álvaro Mondéjar Rubio <mondejar1994@gmail.com>\n"

--- a/mkdocs/themes/mkdocs/locales/fa/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/fa/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2022-03-03 15:49+0330\n"
 "Last-Translator: Peyman Mohammadi <@peymanr34>\n"

--- a/mkdocs/themes/mkdocs/locales/fr/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/fr/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2021-02-23 23:56+0100\n"
 "Last-Translator: Alexys Jacob @ultrabug\n"

--- a/mkdocs/themes/mkdocs/locales/id/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/id/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2023-03-12 13:50+0800\n"
 "Last-Translator: Kira <kiraware@github.com>\n"

--- a/mkdocs/themes/mkdocs/locales/it/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/it/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2022-06-05 12:23+0200\n"
 "Last-Translator: Francesco Maida <francesco.maida@gmail.com>\n"

--- a/mkdocs/themes/mkdocs/locales/ja/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/ja/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2021-07-31 12:06+0900\n"
 "Last-Translator: Goto Hayato <habita.gh@gmail.com>\n"

--- a/mkdocs/themes/mkdocs/locales/nb/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/nb/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2022-10-26 11:10+0200\n"
 "Last-Translator: Per Christian Gaustad <pcgaustad@mailbox.org>\n"

--- a/mkdocs/themes/mkdocs/locales/nl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/nl/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.5.3\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2024-08-12 11:34+0200\n"
 "Last-Translator: Jeroen van de Nieuwenhof <jeroen@tolkie.nl>\n"

--- a/mkdocs/themes/mkdocs/locales/nn/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/nn/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2022-10-26 11:10+0200\n"
 "Last-Translator: Per Christian Gaustad <pcgaustad@mailbox.org>\n"

--- a/mkdocs/themes/mkdocs/locales/pl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/pl/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2024-03-21 17:46+0100\n"
 "Last-Translator: Szymon Rakowski <szymon.rakowski@ac.com.pl>\n"

--- a/mkdocs/themes/mkdocs/locales/pt_BR/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/pt_BR/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2021-09-07 12:06+0200\n"
 "Last-Translator: Nicole Buitoni <ni.buitoni@gmail.com>\n"

--- a/mkdocs/themes/mkdocs/locales/ru/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/ru/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2022-09-13 23:23+0300\n"
 "Last-Translator: Alexander Krasnikov <alexander@krasnikov.net>\n"

--- a/mkdocs/themes/mkdocs/locales/tr/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/tr/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2022-08-21 18:58+0300\n"
 "Last-Translator: Mustafa Sami Salt <mss1451@gmail.com>\n"

--- a/mkdocs/themes/mkdocs/locales/uk/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/uk/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2022-09-17 15:51+0200\n"
 "Last-Translator: Oleh Prypin <@oprypin>\n"

--- a/mkdocs/themes/mkdocs/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/zh_CN/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2024-04-26 06:34+0800\n"
 "Last-Translator: xingkong0113 <dingpengyu06@gmail.com>\n"

--- a/mkdocs/themes/mkdocs/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/mkdocs/locales/zh_TW/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: 2023-09-06 02:13+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"

--- a/mkdocs/themes/mkdocs/messages.pot
+++ b/mkdocs/themes/mkdocs/messages.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.5.3\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-18 21:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/mkdocs/themes/readthedocs/css/theme_extra.css
+++ b/mkdocs/themes/readthedocs/css/theme_extra.css
@@ -2,9 +2,9 @@
  * Wrap inline code samples otherwise they shoot of the side and
  * can't be read at all.
  *
- * https://github.com/mkdocs/mkdocs/issues/313
- * https://github.com/mkdocs/mkdocs/issues/233
- * https://github.com/mkdocs/mkdocs/issues/834
+ * https://github.com/mkdocs-ng/mkdocs/issues/313
+ * https://github.com/mkdocs-ng/mkdocs/issues/233
+ * https://github.com/mkdocs-ng/mkdocs/issues/834
  */
 .rst-content code {
     white-space: pre-wrap;
@@ -16,9 +16,9 @@
  * Make code blocks display as blocks and give them the appropriate
  * font size and padding.
  *
- * https://github.com/mkdocs/mkdocs/issues/855
- * https://github.com/mkdocs/mkdocs/issues/834
- * https://github.com/mkdocs/mkdocs/issues/233
+ * https://github.com/mkdocs-ng/mkdocs/issues/855
+ * https://github.com/mkdocs-ng/mkdocs/issues/834
+ * https://github.com/mkdocs-ng/mkdocs/issues/233
  */
 .rst-content pre code {
     white-space: pre;
@@ -31,7 +31,7 @@
 /**
  * Fix code colors
  *
- * https://github.com/mkdocs/mkdocs/issues/2027
+ * https://github.com/mkdocs-ng/mkdocs/issues/2027
  */
 .rst-content code {
     color: #E74C3C;
@@ -45,7 +45,7 @@
 /*
  * Fix link colors when the link text is inline code.
  *
- * https://github.com/mkdocs/mkdocs/issues/718
+ * https://github.com/mkdocs-ng/mkdocs/issues/718
  */
 a code {
     color: #2980B9;
@@ -62,7 +62,7 @@ a:visited code {
  * ReadTheDocs theme causing some code to be incorrectly made
  * bold and italic.
  *
- * https://github.com/mkdocs/mkdocs/issues/411
+ * https://github.com/mkdocs-ng/mkdocs/issues/411
  */
 pre .cs, pre .c {
     font-weight: inherit;
@@ -74,7 +74,7 @@ pre .cs, pre .c {
  * samples. Without and highlighting styles attached the
  * formatting is broken.
  *
- * https://github.com/mkdocs/mkdocs/issues/319
+ * https://github.com/mkdocs-ng/mkdocs/issues/319
  */
 .rst-content .no-highlight {
     display: block;
@@ -110,7 +110,7 @@ form .search-query {
 /*
  * Improve inline code blocks within admonitions.
  *
- * https://github.com/mkdocs/mkdocs/issues/656
+ * https://github.com/mkdocs-ng/mkdocs/issues/656
  */
  .rst-content .admonition code {
     color: #404040;
@@ -124,8 +124,8 @@ form .search-query {
  * Account for wide tables which go off the side.
  * Override borders to avoid weirdness on narrow tables.
  *
- * https://github.com/mkdocs/mkdocs/issues/834
- * https://github.com/mkdocs/mkdocs/pull/1034
+ * https://github.com/mkdocs-ng/mkdocs/issues/834
+ * https://github.com/mkdocs-ng/mkdocs/pull/1034
  */
 .rst-content .section .docutils {
     width: 100%;
@@ -149,7 +149,7 @@ td, th {
  * line-height, and then applying a padding-bottom of 40px to this container. In
  * a second step, the items within that container are re-aligned using flexbox.
  *
- * https://github.com/mkdocs/mkdocs/issues/2012
+ * https://github.com/mkdocs-ng/mkdocs/issues/2012
  */
  .wy-nav-side {
     padding-bottom: 40px;
@@ -174,7 +174,7 @@ td, th {
  *    <repo_name>        Next >>      // On the first page
  * <repo_name>  << Previous  Next >>  // On all subsequent pages
  *
- * https://github.com/mkdocs/mkdocs/issues/2012
+ * https://github.com/mkdocs-ng/mkdocs/issues/2012
  */
 .rst-versions .rst-current-version {
     padding: 0 12px;
@@ -189,7 +189,7 @@ td, th {
  * Please note that this amendment also involves removing certain inline-styles
  * from the file ./mkdocs/themes/readthedocs/versions.html.
  *
- * https://github.com/mkdocs/mkdocs/issues/2012
+ * https://github.com/mkdocs-ng/mkdocs/issues/2012
  */
 .rst-current-version span {
     flex: 1;

--- a/mkdocs/themes/readthedocs/js/theme_extra.js
+++ b/mkdocs/themes/readthedocs/js/theme_extra.js
@@ -2,7 +2,7 @@
  * Assign 'docutils' class to tables so styling and
  * JavaScript behavior is applied.
  *
- * https://github.com/mkdocs/mkdocs/issues/2028
+ * https://github.com/mkdocs-ng/mkdocs/issues/2028
  */
 
 $('div.rst-content table').addClass('docutils');

--- a/mkdocs/themes/readthedocs/locales/de/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/de/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2.3\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2021-10-23 18:52+0200\n"
 "Last-Translator: Marc Dietz <marc@projectleviathan.de>\n"

--- a/mkdocs/themes/readthedocs/locales/es/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/es/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2021-12-06 13:33+0100\n"
 "Last-Translator: Álvaro Mondéjar Rubio <mondejar1994@gmail.com>\n"

--- a/mkdocs/themes/readthedocs/locales/fa/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/fa/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2.2\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2022-03-03 15:56+0330\n"
 "Last-Translator: Peyman Mohammadi <@peymanr34>\n"

--- a/mkdocs/themes/readthedocs/locales/fr/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/fr/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2021-02-23 23:56+0100\n"
 "Last-Translator: Alexys Jacob @ultrabug\n"

--- a/mkdocs/themes/readthedocs/locales/id/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/id/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2023-03-21 21:00+0800\n"
 "Last-Translator: Kira <kiraware@github.com>\n"

--- a/mkdocs/themes/readthedocs/locales/it/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/it/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2022-06-05 13:13+0200\n"
 "Last-Translator: Francesco Maida <francesco.maida@gmail.com>\n"

--- a/mkdocs/themes/readthedocs/locales/ja/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/ja/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2021-07-31 12:07+0900\n"
 "Last-Translator: Goto Hayato <habita.gh@gmail.com>\n"

--- a/mkdocs/themes/readthedocs/locales/nl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/nl/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.5.3\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2024-08-12 11:34+0200\n"
 "Last-Translator: Jeroen van de Nieuwenhof <jeroen@tolkie.nl>\n"

--- a/mkdocs/themes/readthedocs/locales/pl/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/pl/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2024-03-21 17:46+0100\n"
 "Last-Translator: Szymon Rakowski <szymon.rakowski@ac.com.pl>\n"

--- a/mkdocs/themes/readthedocs/locales/pt_BR/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/pt_BR/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2021-09-07 12:06+0200\n"
 "Last-Translator: Gustavo Lucas Valente <gutivalente@gmail.com>\n"

--- a/mkdocs/themes/readthedocs/locales/ru/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/ru/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2022-09-13 23:23+0300\n"
 "Last-Translator: Alexander Krasnikov <alexander@krasnikov.net>\n"

--- a/mkdocs/themes/readthedocs/locales/tr/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/tr/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2022-08-21 18:39+0300\n"
 "Last-Translator: Mustafa Sami Salt <mss1451@gmail.com>\n"

--- a/mkdocs/themes/readthedocs/locales/uk/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/uk/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2022-09-17 15:51+0200\n"
 "Last-Translator: Oleh Prypin <@oprypin>\n"

--- a/mkdocs/themes/readthedocs/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/zh_CN/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.2\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/"
 "issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2024-04-26 06:39+0800\n"

--- a/mkdocs/themes/readthedocs/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/mkdocs/themes/readthedocs/locales/zh_TW/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.3.1\n"
-"Report-Msgid-Bugs-To: \"https://github.com/mkdocs/mkdocs/issues\"\n"
+"Report-Msgid-Bugs-To: \"https://github.com/mkdocs-ng/mkdocs/issues\"\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: 2023-09-06 02:19+0800\n"
 "Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"

--- a/mkdocs/themes/readthedocs/messages.pot
+++ b/mkdocs/themes/readthedocs/messages.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MkDocs 1.5.3\n"
-"Report-Msgid-Bugs-To: https://github.com/mkdocs/mkdocs/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/mkdocs-ng/mkdocs/issues\n"
 "POT-Creation-Date: 2024-04-09 16:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ min-versions = [
 
 [project.urls]
 Documentation = "https://www.mkdocs.org/"
-Source = "https://github.com/mkdocs/mkdocs"
-Issues = "https://github.com/mkdocs/mkdocs/issues"
+Source = "https://github.com/mkdocs-ng/mkdocs"
+Issues = "https://github.com/mkdocs-ng/mkdocs/issues"
 History = "https://www.mkdocs.org/about/release-notes/"
 
 [project.scripts]


### PR DESCRIPTION
- Changed remote URL in GitHub deploy tests to point to mkdocs-ng.
- Updated repo_url in complicated_config mkdocs.yml to mkdocs-ng.
- Modified projects.yaml to reflect mkdocs-ng catalog.
- Adjusted edit URLs in page tests to use mkdocs-ng.
- Updated theme tests to reference mkdocs-ng issues.
- Changed bug report links in locale message files to mkdocs-ng.
- Updated theme_extra.css and theme_extra.js to point to mkdocs-ng issues.
- Updated pyproject.toml to change source and issues URLs to mkdocs-ng.