### PR TITLE
Fix strict anchor validation with verbose logging

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -27,7 +27,7 @@ The current members of the MkDocs-NG team.
 
 ### Fixed
 
-* Fix anchor link validation so `mkdocs build -v --strict` still fails when missing anchors are reported as warnings. #3991
+* Fix anchor link validation so `mkdocs build -v --strict` still fails when missing anchors are reported as warnings. #30
 
 ### Maintenance
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -25,6 +25,10 @@ The current members of the MkDocs-NG team.
 
 ## Version 1.7.1 (Unreleased)
 
+### Fixed
+
+* Fix anchor link validation so `mkdocs build -v --strict` still fails when missing anchors are reported as warnings. #3991
+
 ### Maintenance
 
 * Remove the unmaintained `mergedeep` dependency by replacing it with an internal deep-merge helper for inherited YAML configuration. #29

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -303,7 +303,7 @@ class Page(StructureItem):
         self.present_anchor_ids = (
             extract_anchors_ext.present_anchor_ids | raw_html_ext.present_anchor_ids
         )
-        if log.getEffectiveLevel() > logging.DEBUG:
+        if config.validation.links.anchors > logging.DEBUG:
             self.links_to_anchors = relative_path_ext.links_to_anchors
 
     present_anchor_ids: set[str] | None = None

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import logging
 import os.path
 import re
 import textwrap
@@ -768,6 +769,29 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
         """
         with self._assert_build_logs(expected_logs):
             build.build(cfg)
+
+    @tempdir(
+        files={
+            "index.md": "[missing anchor](#missing)",
+        }
+    )
+    @tempdir()
+    def test_anchor_warning_with_debug_logging(self, site_dir, docs_dir):
+        cfg = load_config(
+            docs_dir=docs_dir, site_dir=site_dir, validation={"anchors": "warn"}
+        )
+
+        pages_log = logging.getLogger("mkdocs.structure.pages")
+        original_level = pages_log.level
+        pages_log.setLevel(logging.DEBUG)
+        try:
+            expected_logs = """
+                WARNING:Doc file 'index.md' contains a link '#missing', but there is no such anchor on this page.
+            """
+            with self._assert_build_logs(expected_logs):
+                build.build(cfg)
+        finally:
+            pages_log.setLevel(original_level)
 
     @tempdir(
         files={


### PR DESCRIPTION
## Summary
- keep anchor-link collection enabled when verbose logging sets page logs to DEBUG
- add regression coverage for anchor validation with debug logging
- document the fix in the 1.7.1 release notes

Fixes mkdocs/mkdocs#3991.