### PR TITLE
Fix `validation.links.not_found` is always reported as INFO for excluded page

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -28,6 +28,7 @@ The current members of the MkDocs-NG team.
 ### Fixed
 
 * Fix anchor link validation so `mkdocs build -v --strict` still fails when missing anchors are reported as warnings. #30
+* Fix `validation.links.not_found` is always reported as INFO for excluded pages. #32
 
 ### Maintenance
 

--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -17,6 +17,7 @@ from markdown.util import AMP_SUBSTITUTE
 
 from mkdocs import utils
 from mkdocs.structure import StructureItem
+from mkdocs.structure.files import InclusionLevel
 from mkdocs.structure.toc import get_toc
 from mkdocs.utils import (
     _removesuffix,
@@ -533,10 +534,12 @@ class _RelativePathTreeprocessor(markdown.treeprocessors.Treeprocessor):
         if target_file.inclusion.is_excluded():
             if self.file.inclusion.is_excluded():
                 warning_level = logging.DEBUG
-            else:
+            elif target_file.inclusion is InclusionLevel.DRAFT:
                 warning_level = min(
                     logging.INFO, self.config.validation.links.not_found
                 )
+            else:
+                warning_level = self.config.validation.links.not_found
             warning = (
                 f"Doc file '{self.file.src_uri}' contains a link to "
                 f"'{target_uri}' which is excluded from the built site."

--- a/mkdocs/tests/build_tests.py
+++ b/mkdocs/tests/build_tests.py
@@ -705,6 +705,29 @@ class BuildTests(PathAssertionMixin, unittest.TestCase):
 
     @tempdir(
         files={
+            "index.md": "[asdf](./asdf.md)",
+            "asdf.md": "excluded content",
+        }
+    )
+    @tempdir()
+    def test_excluded_page_link_uses_not_found_validation_level(
+        self, site_dir, docs_dir
+    ):
+        cfg = load_config(
+            docs_dir=docs_dir,
+            site_dir=site_dir,
+            validation=dict(links=dict(not_found="warn")),
+            exclude_docs="/asdf.md",
+        )
+
+        expected_logs = """
+            WARNING:Doc file 'index.md' contains a link to 'asdf.md' which is excluded from the built site.
+        """
+        with self._assert_build_logs(expected_logs):
+            build.build(cfg)
+
+    @tempdir(
+        files={
             "foo/README.md": "page1 content",
             "foo/index.md": "page2 content",
         }


### PR DESCRIPTION
## Related Issue

Fixes https://github.com/mkdocs/mkdocs/issues/3900

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [ ] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [x] Release notes `docs/about/release-notes.md` updated (if applicable)
