### PR TITLE
Fix dropdown submenu arrow invisible in non-hovered state

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,6 +23,12 @@ The current members of the MkDocs-NG team.
 
 * [@shenxianpeng](https://github.com/shenxianpeng)
 
+## Version 1.7.2 (Unreleased)
+
+### Fixed
+
+* Fix dropdown submenu arrow invisible in the navigation menu. #3909
+
 ## Version 1.7.1 (2026-04-25)
 
 ### Fixed

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -27,7 +27,7 @@ The current members of the MkDocs-NG team.
 
 ### Fixed
 
-* Fix dropdown submenu arrow invisible in the navigation menu. #3909
+* Fix dropdown submenu arrow invisible in the navigation menu. #44
 
 ## Version 1.7.1 (2026-04-25)
 

--- a/mkdocs/themes/mkdocs/css/base.css
+++ b/mkdocs/themes/mkdocs/css/base.css
@@ -323,7 +323,7 @@ details h4, details h5, details h6 {
     border-color: transparent;
     border-style: solid;
     border-width: 5px 0 5px 5px;
-    border-left-color: var(--bs-dropdown-link-active-color);
+    border-left-color: var(--bs-dropdown-link-color);
     margin-top: 5px;
     margin-right: -10px;
 }


### PR DESCRIPTION
The dropdown-submenu arrow was using --bs-dropdown-link-active-color (#fff) which is invisible against the white background. Change to --bs-dropdown-link-color (#ccc) to make the arrow visible, matching the behavior from MkDocs 1.5.2 and earlier.

Closes https://github.com/mkdocs/mkdocs/issues/3909

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [x] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [x] Release notes `docs/about/release-notes.md` updated (if applicable)
