### PR TITLE
Fix build crash caused by broken symlinks

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -23,6 +23,12 @@ The current members of the MkDocs-NG team.
 
 * [@shenxianpeng](https://github.com/shenxianpeng)
 
+## Version 1.7.2 (Unreleased)
+
+### Fixed
+
+* Fix build crash caused by broken (dangling) symlinks in the docs directory. #3785
+
 ## Version 1.7.1 (2026-04-25)
 
 ### Fixed

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -27,7 +27,7 @@ The current members of the MkDocs-NG team.
 
 ### Fixed
 
-* Fix build crash caused by broken (dangling) symlinks in the docs directory. #3785
+* Fix build crash caused by broken (dangling) symlinks in the docs directory. #46
 
 ## Version 1.7.1 (2026-04-25)
 

--- a/mkdocs/tests/utils/utils_tests.py
+++ b/mkdocs/tests/utils/utils_tests.py
@@ -382,6 +382,22 @@ class UtilsTests(unittest.TestCase):
                 if os.path.exists(src):
                     os.chmod(src, stat.S_IRUSR | stat.S_IWUSR)
 
+    @tempdir()
+    @tempdir()
+    def test_copy_broken_symlink(self, src_dir, dst_dir):
+        # Regression test for mkdocs/mkdocs#3785: dangling symlinks should
+        # not crash the build. A warning should be logged and the file skipped.
+        broken_link = os.path.join(src_dir, "broken_link")
+        os.symlink("/nonexistent/path", broken_link)
+        with self.assertLogs("mkdocs", level="WARNING") as cm:
+            utils.copy_file(broken_link, os.path.join(dst_dir, "broken_link"))
+        self.assertTrue(
+            any("Symlink broken" in m for m in cm.output),
+            f"Expected a warning about broken symlink, got: {cm.output}",
+        )
+        # The broken symlink should not have been copied.
+        self.assertFalse(os.path.exists(os.path.join(dst_dir, "broken_link")))
+
     def test_mm_meta_data(self):
         doc = dedent(
             """

--- a/mkdocs/utils/__init__.py
+++ b/mkdocs/utils/__init__.py
@@ -121,6 +121,9 @@ def copy_file(source_path: str, output_path: str) -> None:
     os.makedirs(output_dir, exist_ok=True)
     if os.path.isdir(output_path):
         output_path = os.path.join(output_path, os.path.basename(source_path))
+    if os.path.islink(source_path) and not os.path.exists(os.readlink(source_path)):
+        log.warning(f"Symlink broken, could not copy file: {source_path}")
+        return
     shutil.copyfile(source_path, output_path)
 
 


### PR DESCRIPTION
When a dangling symlink exists in the docs directory, shutil.copyfile raises an exception that crashes the entire build. Check for broken symlinks before copying, log a warning, and skip the file instead of crashing.

Closes https://github.com/mkdocs/mkdocs/issues/3785

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [x] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [x] Release notes `docs/about/release-notes.md` updated (if applicable)
