### PR TITLE
Add environment variable to disable MkDocs 2 warning in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           hatch run +py=${{ matrix.py || matrix.python-version }} ${{ matrix.test-script }}
       - name: Run integration tests
         run: |
+          export DISABLE_MKDOCS_2_WARNING=true
           hatch run +py=${{ matrix.py || matrix.python-version }} integration:test
         shell: bash
       - name: Upload Codecov Results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,6 @@ matrix.type.scripts = [
 path = "mkdocs.yml"
 [tool.hatch.envs.integration]
 detached = false
-[tool.hatch.envs.integration.env]
-DISABLE_MKDOCS_2_WARNING = "true"
 [tool.hatch.envs.integration.scripts]
 test = "python -m mkdocs.tests.integration"
 [[tool.hatch.envs.integration.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,8 @@ matrix.type.scripts = [
 path = "mkdocs.yml"
 [tool.hatch.envs.integration]
 detached = false
+[tool.hatch.envs.integration.env]
+DISABLE_MKDOCS_2_WARNING = "true"
 [tool.hatch.envs.integration.scripts]
 test = "python -m mkdocs.tests.integration"
 [[tool.hatch.envs.integration.matrix]]


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [x] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [ ] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Release notes `docs/about/release-notes.md` updated (if applicable)
