### PR TITLE
Expose page.content_title property for plugin authors

### DIFF
--- a/mkdocs/structure/pages.py
+++ b/mkdocs/structure/pages.py
@@ -97,6 +97,19 @@ class Page(StructureItem):
     """A mapping of the metadata included at the top of the markdown page."""
 
     @property
+    def content_title(self) -> str | None:
+        """
+        The title of the page extracted from the first `<h1>` heading in the page content.
+
+        This is `None` until the page has been rendered. Unlike `title`,
+        this does not fall back to any other source — it reflects exactly
+        the `<h1>` text from the rendered Markdown, with HTML tags stripped
+        and entities unescaped. It is useful for plugins that need the raw
+        heading text as it appears in the page body.
+        """
+        return self._title_from_render
+
+    @property
     def url(self) -> str:
         """The URL of the page relative to the MkDocs `site_dir`."""
         url = self.file.url

--- a/mkdocs/tests/structure/page_tests.py
+++ b/mkdocs/tests/structure/page_tests.py
@@ -329,6 +329,17 @@ class PageTests(unittest.TestCase):
         self.assertEqual(pg.title, "Welcome to MkDocs")
         pg.render(cfg, Files([fl]))
         self.assertEqual(pg.title, "Welcome to MkDocs")
+        self.assertEqual(pg.content_title, "Welcome to MkDocs")
+
+    def test_content_title_property(self):
+        """content_title is None before rendering, set after."""
+        cfg = load_config()
+        fl = File("testing.md", cfg.docs_dir, cfg.site_dir, cfg.use_directory_urls)
+        pg = Page(None, fl, cfg)
+        pg.read_source(cfg)
+        self.assertIsNone(pg.content_title)
+        pg.render(cfg, Files([fl]))
+        self.assertEqual(pg.content_title, "Welcome to MkDocs")
 
     def _test_extract_title(self, content, expected, extensions={}):
         md = markdown.Markdown(


### PR DESCRIPTION
Add a public content_title property to the Page class that exposes the previously private _title_from_render attribute. This gives plugin authors access to the heading text extracted from the first `<h1>` tag in the page content, with HTML tags stripped and entities unescaped, without reaching into private API.

Fixes https://github.com/mkdocs/mkdocs/issues/3532

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [x] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Release notes `docs/about/release-notes.md` updated (if applicable)
