### PR TITLE
Strip HTML tags from search entry titles

### DIFF
--- a/mkdocs/contrib/search/search_index.py
+++ b/mkdocs/contrib/search/search_index.py
@@ -8,6 +8,8 @@ import subprocess
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING
 
+from mkdocs.utils.rendering import _strip_tags
+
 if TYPE_CHECKING:
     from mkdocs.structure.pages import Page
     from mkdocs.structure.toc import AnchorLink, TableOfContents
@@ -49,6 +51,11 @@ class SearchIndex:
         """A simple wrapper to add an entry, dropping bad characters."""
         text = text.replace("\u00a0", " ")
         text = re.sub(r"[ \t\n\r\f\v]+", " ", text.strip())
+
+        # Strip HTML tags from the title to prevent raw HTML from appearing
+        # in search results (which could also be an XSS vector).
+        if title is not None:
+            title = _strip_tags(title)
 
         self._entries.append({"title": title, "text": text, "location": loc})
 

--- a/mkdocs/tests/search_tests.py
+++ b/mkdocs/tests/search_tests.py
@@ -651,3 +651,32 @@ class SearchIndexTests(unittest.TestCase):
         self.assertEqual(mock_popen.call_count, 1)
         self.assertEqual(mock_popen_obj.communicate.call_count, 1)
         self.assertEqual(result, expected)
+
+    def test_html_stripped_from_titles(self):
+        """HTML tags in page and section titles are stripped from search entries."""
+        plugin = search.SearchPlugin()
+        errors, warnings = plugin.load_config({})
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+        config = load_config(plugins=["search"])
+        # A page title with inline HTML from Markdown (e.g. `<code>foo</code>`)
+        page = Page(
+            "The <code>mkdocs</code> Project",
+            File(
+                "index.md", config.docs_dir, config.site_dir, config.use_directory_urls
+            ),
+            config,
+        )
+        page.content = """
+            <h1 id="heading-1">Heading <em>one</em></h1>
+            <p>Content</p>"""
+        page.markdown = "# Heading 1\n\nContent"
+        page.toc = get_toc(get_markdown_toc(page.markdown))
+
+        index = search_index.SearchIndex(**plugin.config)
+        index.add_entry_from_context(page)
+
+        self.assertEqual(len(index._entries), 2)
+        self.assertEqual(index._entries[0]["title"], "The mkdocs Project")
+        self.assertEqual(index._entries[1]["title"], "Heading 1")


### PR DESCRIPTION
Sanitize page and section titles in the search index by stripping any HTML tags using the existing _strip_tags utility. This prevents raw HTML from appearing in search results, which is both a UI issue and a potential XSS vector when page titles contain inline HTML from Markdown rendering.

Fixes https://github.com/mkdocs/mkdocs/issues/3560  https://github.com/mkdocs/mkdocs/issues/3213

<!-- A clear and concise description of what this PR does. -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->
Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [x] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Release notes `docs/about/release-notes.md` updated (if applicable)
