### PR TITLE
Pin click <8.3.0 to prevent livereload and use_directory_urls breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.8"
 dependencies = [
-    "click >=7.0",
+    "click >=7.0, <8.3.0",
     "Jinja2 >=2.11.1",
     "markupsafe >=2.0.1",
     "Markdown >=3.3.6",


### PR DESCRIPTION
click>=8.3.0 introduces breaking changes that affect file watching (livereload) and use_directory_urls. Pin to <8.3.0 to prevent users from accidentally upgrading to a broken version.

Fixes #4032, #4014, #4055

<!-- A clear and concise description of what this PR does. -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->
Fixes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [ ] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Release notes `docs/about/release-notes.md` updated (if applicable)
