### PR TITLE
Add mypy type checking to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,10 @@ repos:
         entry: npm exec --yes -- jshint
         language: system
         files: ^mkdocs/.*\.js$
+      - id: mypy
+        name: mypy
+        entry: hatch run types:check
+        language: system
+        pass_filenames: false
+        always_run: false
+        require_serial: true


### PR DESCRIPTION
Add 'hatch run types:check' as a pre-commit hook to catch type errors before they reach CI. Uses pass_filenames: false since mypy needs to check the entire project (not just staged files).

This matches the existing 'hatch run types:check' command documented in CONTRIBUTING.md.

<!-- A clear and concise description of what this PR does. -->

## Related Issue

<!-- Link to the issue this PR addresses, if applicable. -->
Fixes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [x] CI / build / dependency update
- [ ] Other (describe below)

## Checklist

- [ ] New tests added for new behavior (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] Release notes `docs/about/release-notes.md` updated (if applicable)
